### PR TITLE
Corrected preinstall script to post hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,8 @@
     "development": "webpack-dev-server",
     "deploy": "NODE_ENV=production webpack -p --config webpack.production.config.js",
     "server": "node server",
-    "preinstall": "NODE_ENV=production webpack -p --config webpack.production.config.js",
-    "start": "node server",
-    "postinstall": "echo installation finish"
+    "start": "npm run server",
+    "postinstall": "NODE_ENV=production webpack -p --config webpack.production.config.js"
   },
   "keywords": [],
   "author": "Javier Valencia Romero",


### PR DESCRIPTION
The preinstall script was trying to run webpack, but webpack hasn't
installed yet with that hook. I've updated it to be a post hook.

I also made some improvements to lessen redundancy in the package.json.
The post hook was only echoing finished which isn't as elegant as simply
exiting cleanly without an error code.