### PR TITLE
Fix undo if setting pixel

### DIFF
--- a/src/components/Pixel-cell.jsx
+++ b/src/components/Pixel-cell.jsx
@@ -70,7 +70,6 @@ export const PixelCell = React.createClass({
             onMouseDown={this.handleMouseDown}
             onMouseUp={this.props.endDrag}
             onMouseOver={this.handleDrag}
-            onClick={this.handleClick}
             style={styles.cell}>
         </div>
       </div>

--- a/src/components/UndoRedo.jsx
+++ b/src/components/UndoRedo.jsx
@@ -4,9 +4,7 @@ import * as actionCreators from '../action_creators';
 
 export const UndoRedo = React.createClass({
   undo: function() {
-    if (this.props.pastStatesCount > 1) {
       this.props.undo();
-    }
   },
   redo: function() {
     this.props.redo();
@@ -30,12 +28,7 @@ export const UndoRedo = React.createClass({
   }
 });
 
-function mapStateToProps(state) {
-  return {
-    pastStatesCount: state.past ? state.past.length : 0
-  };
-}
 export const UndoRedoContainer = connect(
-  mapStateToProps,
+  null,
   actionCreators
 )(UndoRedo);


### PR DESCRIPTION
Pull request does two small things:
* cleans up `UndoRedo` component code: library correctly handles corner cases internally
* Fixes bug: if you just tick one pixel, two consecutive draw events were fired: `onMouseDown` and `onClick`, if you tap 'Undo' after it, it rolled back only one of the actions causing colored pixel to remain colored.


P.S. tests were failing for me before this change.