### PR TITLE
Fix - File upload persists out of sync frame count and pixel size from the previous selection

### DIFF
--- a/src/components/loadFromFile/index.jsx
+++ b/src/components/loadFromFile/index.jsx
@@ -154,6 +154,8 @@ const LoadFromFile = props => {
           );
         }
       );
+      setFrameCount(1);
+      setPixelSize(1);
       if (imageLoadedData.errorType) {
         setImageLoaded(false);
         showValidationMessage({


### PR DESCRIPTION
## Issue
On upload from the image tab, selecting a new image doesn't reset the frame count and pixel size from the previously selected image where we change the frame count or pixel size.
### Steps to Reproduce
1. Upload an image.
2. Change the frame count and pixel size.
3. Upload a different image.
4. Frame count and pixel size doesn't change whereas frame size is displayed from frame count=1 & pixel size=1

## Fix
Reset both frame count & pixel size to 1 when a new image is selected.